### PR TITLE
alternative getUniforms API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,10 @@ Basic usage involves rendering to a WebGL canvas overlayed on the Mapbox element
             canvasHeight: canvas.height
         });
 
-        PicoMercator.forEachUniform(lng, lat, zoom, viewMatrix, projectionMatrix, (name, value) => {
-            // Set PicoMercator uniforms
-        });
+        // PicoMercator uniforms to be set
+        let uniforms = PicoMercator.getUniforms(lng, lat, zoom, viewMatrix, projectionMatrix);
 
         // Draw to canvas
     });
 
-``` 
-
+```

--- a/examples/scatterplot.html
+++ b/examples/scatterplot.html
@@ -202,8 +202,9 @@
                 .uniform("radiusScale", 30)
                 .uniform("radiusLimits", radiusLimits);
 
-                PicoMercator.forEachUniform(lng, lat, mapZoom, viewMat, projMat, (name, value) => {
-                    drawCall.uniform(name, value)
+                let picoUniforms = PicoMercator.getUniforms(lng, lat, mapZoom, viewMat, projMat)
+                Object.keys(picoUniforms).forEach((name) => {
+                    drawCall.uniform(name, picoUniforms[name]);
                 });
 
                 // DRAW
@@ -213,10 +214,6 @@
                 timer.end();
             });
         });
-
-        
-
-
     </script>
 </body>
 </html>

--- a/examples/triangle.html
+++ b/examples/triangle.html
@@ -159,8 +159,9 @@
                     zoom: mapZoom,
                 });
 
-                PicoMercator.forEachUniform(lng, lat, mapZoom, viewMat, projMat, (name, value) => {
-                    drawCall.uniform(name, value)
+                let picoUniforms = PicoMercator.getUniforms(lng, lat, mapZoom, viewMat, projMat)
+                Object.keys(picoUniforms).forEach((name) => {
+                    drawCall.uniform(name, picoUniforms[name]);
                 });
 
                 // DRAW
@@ -168,8 +169,6 @@
                 drawCall.draw();
             });
         });
-
-
     </script>
 </body>
 </html>

--- a/src/pico-mercator.js
+++ b/src/pico-mercator.js
@@ -159,27 +159,25 @@ export const PicoMercator = {
         return out;
     },
 
-    forEachUniform(longitude, latitude, zoom, viewMatrix, projectionMatrix, fn) {
+    getUniforms(longitude, latitude, zoom, viewMatrix, projectionMatrix) {
         tempLngLatCenter32[0] = longitude;
         tempLngLatCenter32[1] = latitude;
 
-        fn("PICO_lngLatCenter", tempLngLatCenter32);
-
         this.pixelsPerDegree(tempPixelsPerDegree32, latitude);
-
-        fn("PICO_pixelsPerDegree", tempPixelsPerDegree32);
 
         this.lngLatToWorld(tempCenter64, longitude, latitude);
         vec4.transformMat4(tempCenter64, tempCenter64, viewMatrix);
         vec4.transformMat4(tempClipCenter32, tempCenter64, projectionMatrix);
 
-        fn("PICO_clipCenter", tempClipCenter32);
-
-        fn("PICO_scale", Math.pow(2, zoom));
-
         mat4.multiply(tempViewProjectionMatrix32, projectionMatrix, viewMatrix);
 
-        fn("PICO_viewProjectionMatrix", tempViewProjectionMatrix32);
+        return {
+            PICO_scale: Math.pow(2, zoom),
+            PICO_lngLatCenter: tempLngLatCenter32,
+            PICO_pixelsPerDegree: tempPixelsPerDegree32,
+            PICO_clipCenter: tempClipCenter32,
+            PICO_viewProjectionMatrix: tempViewProjectionMatrix32
+        }
     },
 
     pixelsPerMeter(latitude) {


### PR DESCRIPTION
Having `forEachUniform` call a user-supplied function synchronously seems like an awkward way to essentially just return some uniforms and their values to the user. It also might imply that there's something fancy going on behind the scenes which requires calling the user-supplied function asynchronously or calling them in a particular order. I wonder if returning an object would be more straight-forward.

I don't feel too strongly about this, but figured I'd open the PR so there's a place to have that conversation, even if it's just a quick one!